### PR TITLE
投稿削除

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-    before_action :set_post, only: [:edit, :update]
+    before_action :set_post, only: [:edit, :update, :destroy]
 
     def index
         @posts = Post.all
@@ -24,6 +24,12 @@ class PostsController < ApplicationController
     def update
         if @post.update(post_params)
             redirect_to posts_path, notice: '投稿を編集しました。'
+        end
+    end
+
+    def destroy
+        if @post.destroy
+            redirect_to posts_path, notice: '投稿を削除しました。'
         end
     end
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,6 +9,7 @@
     <li>
       <%= post.title %>
       <a href="<%= edit_post_path(post.id) %>">編集</a>
+      <%= link_to "削除", post_path(post.id), method: :delete, data: { turbo_method: 'delete', turbo_confirm: '本当に削除しますか' } %>
     </li>
   <% end %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
 
-  resources :posts
+  resources :posts, only: [:index, :new, :create, :edit, :update, :destroy]
 end


### PR DESCRIPTION
## 画面
<img width="283" alt="image" src="https://github.com/ToBeSD/rails-CRUD/assets/86786032/0809541a-6da5-482a-b107-dfa01404cd35">

## 概要
削除ボタンを追加した！

## 学んだこと

ActiveRepordのレコードを削除するためのメソットは複数ある

メモリ使用量などの違いもあると聞いたが今の段階ではスキープする

- delete
  - そのモデルのレコードのみ削除する
  
- destroy
  - そのモデルのレコードを削除する
  - また、関連のレコードも削除する
  - これはリレーション関係のレコードも削除するっていう認識で理解した
  - 間違っている可能性もある、、
  
## 疑問点

`DB`を設計する時に`cascade`設定をすることで`destroy`メソットの動作を実現できると思った。
`ruby on rails`が`destroy`メソットを用意した理由があるはずだが、今の段階ではよくわからない。
